### PR TITLE
Tweak link markup

### DIFF
--- a/lib/table_of_contents/heading_tree_renderer.rb
+++ b/lib/table_of_contents/heading_tree_renderer.rb
@@ -13,7 +13,7 @@ module TableOfContents
       output = ''
 
       if tree.heading
-        output+= indentation + %{<a href="#{tree.heading.href}">#{tree.heading.title}</a>\n}
+        output+= indentation + %{<a class="toc-link" href="#{tree.heading.href}">#{tree.heading.title}</a>\n}
       end
 
       if tree.children.any?


### PR DESCRIPTION
It's useful to have a `toc-link` class on the anchors in the generated
TOC for use in JavaScript. This adds that.