### PR TITLE
Linting / semantic fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+AllCops:
+  TargetRubyVersion: 2.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: ruby
+rvm:
+  - 2.3.3
+script: bundle exec rspec .

--- a/lib/table_of_contents/heading.rb
+++ b/lib/table_of_contents/heading.rb
@@ -20,8 +20,8 @@ module TableOfContents
 
     def ==(other)
       @element_name == other.instance_variable_get("@element_name") &&
-      @text == other.instance_variable_get("@text") &&
-      @attributes == other.instance_variable_get("@attributes")
+        @text == other.instance_variable_get("@text") &&
+        @attributes == other.instance_variable_get("@attributes")
     end
   end
 end

--- a/lib/table_of_contents/heading_tree.rb
+++ b/lib/table_of_contents/heading_tree.rb
@@ -18,10 +18,10 @@ module TableOfContents
 
     def ==(other)
       heading == other.heading &&
-      children.length == other.children.length &&
-      children.map.with_index do |child, index|
-        child == other.children[index]
-      end.all?
+        children.length == other.children.length &&
+        children.map.with_index do |child, index|
+          child == other.children[index]
+        end.all?
     end
   end
 end

--- a/lib/table_of_contents/heading_tree_builder.rb
+++ b/lib/table_of_contents/heading_tree_builder.rb
@@ -17,6 +17,7 @@ module TableOfContents
     end
 
   private
+
     def move_to_depth(depth)
       if depth > @pointer.depth
         @pointer = @pointer.children.last

--- a/lib/table_of_contents/heading_tree_renderer.rb
+++ b/lib/table_of_contents/heading_tree_renderer.rb
@@ -9,23 +9,24 @@ module TableOfContents
     end
 
   private
+
     def render_tree(tree, indentation = '')
       output = ''
 
       if tree.heading
-        output+= indentation + %{<a href="#{tree.heading.href}">#{tree.heading.title}</a>\n}
+        output += indentation + %{<a href="#{tree.heading.href}">#{tree.heading.title}</a>\n}
       end
 
       if tree.children.any?
-        output+= indentation + "<ul>\n"
+        output += indentation + "<ul>\n"
 
         tree.children.each do |child|
-          output+= indentation + indentation_increment + "<li>\n"
-          output+= render_tree(child, indentation + indentation_increment * 2)
-          output+= indentation + indentation_increment + "</li>\n"
+          output += indentation + indentation_increment + "<li>\n"
+          output += render_tree(child, indentation + indentation_increment * 2)
+          output += indentation + indentation_increment + "</li>\n"
         end
 
-        output+= indentation + "</ul>\n"
+        output += indentation + "</ul>\n"
       end
 
       output

--- a/lib/table_of_contents/headings_builder.rb
+++ b/lib/table_of_contents/headings_builder.rb
@@ -17,6 +17,7 @@ module TableOfContents
     end
 
   private
+
     def page
       @_page ||= Nokogiri::HTML(@html)
     end
@@ -27,7 +28,7 @@ module TableOfContents
 
     def convert_nokogiri_attr_objects_to_hashes(attributes)
       attributes.tap do |hash|
-        hash.each do |k,v|
+        hash.each do |k, v|
           hash[k] = v.value
         end
       end

--- a/spec/heading_spec.rb
+++ b/spec/heading_spec.rb
@@ -10,7 +10,7 @@ end
 
 describe TableOfContents::Heading, '#href' do
   it 'returns a fragment href' do
-    heading = described_class.new(element_name: '', text: '', attributes: {'id' => 'apple-recipes'})
+    heading = described_class.new(element_name: '', text: '', attributes: { 'id' => 'apple-recipes' })
 
     expect(heading.href).to eq('#apple-recipes')
   end
@@ -26,28 +26,28 @@ end
 
 describe TableOfContents::Heading, '#==' do
   it 'is true if the element_name, text and attributes match' do
-    a = described_class.new(element_name: 'h1', text: 'Cars', attributes: {'id' => 'cars'})
-    b = described_class.new(element_name: 'h1', text: 'Cars', attributes: {'id' => 'cars'})
+    a = described_class.new(element_name: 'h1', text: 'Cars', attributes: { 'id' => 'cars' })
+    b = described_class.new(element_name: 'h1', text: 'Cars', attributes: { 'id' => 'cars' })
 
     expect(a).to eq(b)
   end
 
   it 'is false if the element_name differs' do
-    a = described_class.new(element_name: 'h1', text: 'Cars', attributes: {'id' => 'cars'})
-    b = described_class.new(element_name: 'h2', text: 'Cars', attributes: {'id' => 'cars'})
+    a = described_class.new(element_name: 'h1', text: 'Cars', attributes: { 'id' => 'cars' })
+    b = described_class.new(element_name: 'h2', text: 'Cars', attributes: { 'id' => 'cars' })
 
     expect(a).to_not eq(b)
   end
 
   it 'is false if the text differs' do
-    a = described_class.new(element_name: 'h1', text: 'Cars', attributes: {'id' => 'cars'})
-    b = described_class.new(element_name: 'h1', text: 'Boats', attributes: {'id' => 'cars'})
+    a = described_class.new(element_name: 'h1', text: 'Cars', attributes: { 'id' => 'cars' })
+    b = described_class.new(element_name: 'h1', text: 'Boats', attributes: { 'id' => 'cars' })
 
     expect(a).to_not eq(b)
   end
 
   it 'is false if the attributes differ' do
-    a = described_class.new(element_name: 'h1', text: 'Cars', attributes: {'id' => 'cars'})
+    a = described_class.new(element_name: 'h1', text: 'Cars', attributes: { 'id' => 'cars' })
     b = described_class.new(element_name: 'h1', text: 'Cars', attributes: {})
 
     expect(a).to_not eq(b)

--- a/spec/heading_tree_builder_spec.rb
+++ b/spec/heading_tree_builder_spec.rb
@@ -3,27 +3,27 @@ require 'spec_helper'
 describe TableOfContents::HeadingTreeBuilder do
   it 'creates a tree of headings depending on their size' do
     headings = [
-      TableOfContents::Heading.new(element_name: 'h1', text: 'Apples', attributes: {'id' => 'apples'}),
-      TableOfContents::Heading.new(element_name: 'h3', text: 'Apple recipes', attributes: {'id' => 'apple-recipes'}),
-      TableOfContents::Heading.new(element_name: 'h1', text: 'Oranges', attributes: {'id' => 'oranges'})
+      TableOfContents::Heading.new(element_name: 'h1', text: 'Apples', attributes: { 'id' => 'apples' }),
+      TableOfContents::Heading.new(element_name: 'h3', text: 'Apple recipes', attributes: { 'id' => 'apple-recipes' }),
+      TableOfContents::Heading.new(element_name: 'h1', text: 'Oranges', attributes: { 'id' => 'oranges' })
     ]
 
     expected_tree = TableOfContents::HeadingTree.new(
       children: [
         TableOfContents::HeadingTree.new(
-          heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Apples', attributes: {'id' => 'apples'}),
+          heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Apples', attributes: { 'id' => 'apples' }),
           children: [
             TableOfContents::HeadingTree.new(
               children: [
                 TableOfContents::HeadingTree.new(
-                  heading: TableOfContents::Heading.new(element_name: 'h3', text: 'Apple recipes', attributes: {'id' => 'apple-recipes'})
+                  heading: TableOfContents::Heading.new(element_name: 'h3', text: 'Apple recipes', attributes: { 'id' => 'apple-recipes' })
                 )
               ]
             )
           ]
         ),
         TableOfContents::HeadingTree.new(
-          heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Oranges', attributes: {'id' => 'oranges'}),
+          heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Oranges', attributes: { 'id' => 'oranges' }),
         )
       ]
     )

--- a/spec/heading_tree_renderer_spec.rb
+++ b/spec/heading_tree_renderer_spec.rb
@@ -6,15 +6,15 @@ describe TableOfContents::HeadingTreeRenderer, '#html' do
       heading: nil,
       children: [
         TableOfContents::HeadingTree.new(
-          heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Apples', attributes: {'id' => 'apples'}),
+          heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Apples', attributes: { 'id' => 'apples' }),
           children: [
             TableOfContents::HeadingTree.new(
-              heading: TableOfContents::Heading.new(element_name: 'h2', text: 'Apple recipes', attributes: {'id' => 'apple-recipes'})
+              heading: TableOfContents::Heading.new(element_name: 'h2', text: 'Apple recipes', attributes: { 'id' => 'apple-recipes' })
             )
           ]
         ),
         TableOfContents::HeadingTree.new(
-          heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Oranges', attributes: {'id' => 'oranges'}),
+          heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Oranges', attributes: { 'id' => 'oranges' }),
         )
       ]
     )

--- a/spec/heading_tree_spec.rb
+++ b/spec/heading_tree_spec.rb
@@ -5,10 +5,10 @@ describe TableOfContents::HeadingTree, '#==' do
     a = TableOfContents::HeadingTree.new(
       children: [
         TableOfContents::HeadingTree.new(
-          heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Apples', attributes: {'id' => 'apples'}),
+          heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Apples', attributes: { 'id' => 'apples' }),
           children: [
             TableOfContents::HeadingTree.new(
-              heading: TableOfContents::Heading.new(element_name: 'h2', text: 'Seeds', attributes: {'id' => 'seeds'}),
+              heading: TableOfContents::Heading.new(element_name: 'h2', text: 'Seeds', attributes: { 'id' => 'seeds' }),
             )
           ]
         )
@@ -17,10 +17,10 @@ describe TableOfContents::HeadingTree, '#==' do
     b = TableOfContents::HeadingTree.new(
       children: [
         TableOfContents::HeadingTree.new(
-          heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Apples', attributes: {'id' => 'apples'}),
+          heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Apples', attributes: { 'id' => 'apples' }),
           children: [
             TableOfContents::HeadingTree.new(
-              heading: TableOfContents::Heading.new(element_name: 'h2', text: 'Seeds', attributes: {'id' => 'seeds'}),
+              heading: TableOfContents::Heading.new(element_name: 'h2', text: 'Seeds', attributes: { 'id' => 'seeds' }),
             )
           ]
         )
@@ -34,17 +34,17 @@ describe TableOfContents::HeadingTree, '#==' do
     a = TableOfContents::HeadingTree.new(
       children: [
         TableOfContents::HeadingTree.new(
-          heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Apples', attributes: {'id' => 'apples'}),
+          heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Apples', attributes: { 'id' => 'apples' }),
         ),
         TableOfContents::HeadingTree.new(
-          heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Oranges', attributes: {'id' => 'oranges'}),
+          heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Oranges', attributes: { 'id' => 'oranges' }),
         )
       ]
     )
     b = TableOfContents::HeadingTree.new(
       children: [
         TableOfContents::HeadingTree.new(
-          heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Apples', attributes: {'id' => 'apples'}),
+          heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Apples', attributes: { 'id' => 'apples' }),
         )
       ]
     )
@@ -54,10 +54,10 @@ describe TableOfContents::HeadingTree, '#==' do
 
   it 'is false if a heading differs' do
     a = TableOfContents::HeadingTree.new(
-      heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Apples', attributes: {'id' => 'apples'}),
+      heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Apples', attributes: { 'id' => 'apples' }),
     )
     b = TableOfContents::HeadingTree.new(
-      heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Oranges', attributes: {'id' => 'oranges'}),
+      heading: TableOfContents::Heading.new(element_name: 'h1', text: 'Oranges', attributes: { 'id' => 'oranges' }),
     )
 
     expect(a).to_not eq(b)

--- a/spec/headings_builder_spec.rb
+++ b/spec/headings_builder_spec.rb
@@ -13,9 +13,9 @@ describe TableOfContents::HeadingsBuilder do
     headings = described_class.new(html).headings
 
     expect(headings).to eq([
-      TableOfContents::Heading.new(element_name: 'h1', text: 'Apples', attributes: {'id' => 'apples'}),
-      TableOfContents::Heading.new(element_name: 'h2', text: 'Apple recipes', attributes: {'id' => 'apple-recipes'}),
-      TableOfContents::Heading.new(element_name: 'h1', text: 'Pears', attributes: {'id' => 'pears'}),
+      TableOfContents::Heading.new(element_name: 'h1', text: 'Apples', attributes: { 'id' => 'apples' }),
+      TableOfContents::Heading.new(element_name: 'h2', text: 'Apple recipes', attributes: { 'id' => 'apple-recipes' }),
+      TableOfContents::Heading.new(element_name: 'h1', text: 'Pears', attributes: { 'id' => 'pears' }),
     ])
   end
 end

--- a/table_of_contents.gemspec
+++ b/table_of_contents.gemspec
@@ -9,4 +9,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'nokogiri'
   s.add_development_dependency 'rspec'
+  s.add_development_dependency 'govuk-lint'
 end


### PR DESCRIPTION
# Overview

This PR does a few hygiene-related bits and pieces:

- `.gitignore`s the `Gemfile.lock` of the project, which [shouldn't be committed into version control](http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/)
- Adds `govuk-lint` to the development dependencies of the project
- Fixes a bunch of linting errors per govuk-lint's rules
- Adds a valid `.travis.yml`, which:
  - Runs `bundle exec rspec .` to determine whether tests pass
  - Runs the suite against Ruby 2.3.3
  - Negates the need for #2 😞 

# Questions

- Should we run the test suite against other versions of Ruby? [alphagov/tech-docs-template](https://github.com/alphagov/tech-docs-template), the main dependent codebase of this project, runs with Ruby 2.2.2 and above (with the exception of Ruby 2.3.0 exactly, which fails due to a Middleman bug) – should we be testing against more versions?