### PR TITLE
Add configurable "max level" of headings to include

### DIFF
--- a/lib/table_of_contents/heading_tree_renderer.rb
+++ b/lib/table_of_contents/heading_tree_renderer.rb
@@ -1,39 +1,44 @@
 module TableOfContents
   class HeadingTreeRenderer
-    def initialize(heading_tree)
+    DEFAULT_MAX_LEVEL = Float::INFINITY
+    DEFAULT_INDENTATION = ''.freeze
+    INDENTATION_INCREMENT = '  '.freeze
+
+    def initialize(heading_tree, max_level: nil)
       @heading_tree = heading_tree
+      @max_level = max_level || DEFAULT_MAX_LEVEL
     end
 
     def html
-      render_tree(@heading_tree)
+      render_tree(@heading_tree, level: 0)
     end
 
   private
 
-    def render_tree(tree, indentation = '')
+    def render_tree(tree, indentation: DEFAULT_INDENTATION, level: nil)
       output = ''
 
       if tree.heading
         output += indentation + %{<a href="#{tree.heading.href}">#{tree.heading.title}</a>\n}
       end
 
-      if tree.children.any?
+      if tree.children.any? && level < @max_level
         output += indentation + "<ul>\n"
 
         tree.children.each do |child|
-          output += indentation + indentation_increment + "<li>\n"
-          output += render_tree(child, indentation + indentation_increment * 2)
-          output += indentation + indentation_increment + "</li>\n"
+          output += indentation + INDENTATION_INCREMENT + "<li>\n"
+          output += render_tree(
+            child,
+            indentation: indentation + INDENTATION_INCREMENT * 2,
+            level: level + 1
+          )
+          output += indentation + INDENTATION_INCREMENT + "</li>\n"
         end
 
         output += indentation + "</ul>\n"
       end
 
       output
-    end
-
-    def indentation_increment
-      '  '
     end
   end
 end

--- a/lib/table_of_contents/helpers.rb
+++ b/lib/table_of_contents/helpers.rb
@@ -1,10 +1,11 @@
 module TableOfContents
   module Helpers
-    def table_of_contents(html)
+    def table_of_contents(html, max_level: nil)
       HeadingTreeRenderer.new(
         HeadingTreeBuilder.new(
           HeadingsBuilder.new(html).headings
-        ).tree
+        ).tree,
+        max_level: max_level
       ).html
     end
   end

--- a/spec/heading_tree_renderer_spec.rb
+++ b/spec/heading_tree_renderer_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe TableOfContents::HeadingTreeRenderer, '#html' do
-  it 'returns a nested unordered list of links to headings' do
-    tree = TableOfContents::HeadingTree.new(
+  let(:tree) {
+    TableOfContents::HeadingTree.new(
       heading: nil,
       children: [
         TableOfContents::HeadingTree.new(
@@ -18,25 +18,50 @@ describe TableOfContents::HeadingTreeRenderer, '#html' do
         )
       ]
     )
+  }
 
-    html = described_class.new(tree).html
-
-    expected_html = %{
-<ul>
-  <li>
-    <a href="#apples">Apples</a>
+  let(:expected_html_with_all_headings) {
+    <<~EOF
     <ul>
       <li>
-        <a href="#apple-recipes">Apple recipes</a>
+        <a href="#apples">Apples</a>
+        <ul>
+          <li>
+            <a href="#apple-recipes">Apple recipes</a>
+          </li>
+        </ul>
+      </li>
+      <li>
+        <a href="#oranges">Oranges</a>
       </li>
     </ul>
-  </li>
-  <li>
-    <a href="#oranges">Oranges</a>
-  </li>
-</ul>
-}
+    EOF
+  }
 
-    expect(html.strip).to eq(expected_html.strip)
+  let(:expected_html_with_max_heading_of_one) {
+    <<~EOF
+    <ul>
+      <li>
+        <a href="#apples">Apples</a>
+      </li>
+      <li>
+        <a href="#oranges">Oranges</a>
+      </li>
+    </ul>
+    EOF
+  }
+
+  context 'without a max_level' do
+    it 'returns a nested list of links to all headings in the tree' do
+      html = described_class.new(tree).html
+      expect(html).to eq(expected_html_with_all_headings)
+    end
+  end
+
+  context 'with a max_level of 1' do
+    it 'returns a nested list of links to top-level headings only' do
+      html = described_class.new(tree, max_level: 1).html
+      expect(html).to eq(expected_html_with_max_heading_of_one)
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'pry'
 require 'table_of_contents'

--- a/table_of_contents.gemspec
+++ b/table_of_contents.gemspec
@@ -10,4 +10,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'nokogiri'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'govuk-lint'
+  s.add_development_dependency 'pry'
 end


### PR DESCRIPTION
At the moment, we include all the headings that we can find in the
document when generating a table of contents. This is fine, but there
are some scenarios where we want to make this configurable – only render
headings up to h3s, for example, to reduce the size of the table of
contents.

This allows the user to pass an options hash to
`Helpers#table_of_contents`, which can include a parameter called
`max_level`. Any headings that are above this level will be ignored.